### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # 1.0.1
 
+## Unreleased
+
+- resolved cookstyle error: libraries/matchers.rb:1:1 convention: `Style/Encoding`
+- resolved cookstyle error: libraries/matchers.rb:3:1 refactor: `Chef/Modernize/DefinesChefSpecMatchers`
+- resolved cookstyle error: libraries/matchers.rb:11:1 convention: `Layout/TrailingEmptyLines`
+- resolved cookstyle error: metadata.rb:4:18 refactor: `Chef/Sharing/InvalidLicenseString`
+- resolved cookstyle error: metadata.rb:6:1 refactor: `Chef/RedundantCode/LongDescriptionMetadata`
+- resolved cookstyle error: metadata.rb:14:1 refactor: `Chef/Modernize/RespondToInMetadata`
+- resolved cookstyle error: providers/service.rb:1:1 warning: `Chef/Deprecations/UseInlineResourcesDefined`
+- resolved cookstyle error: recipes/default.rb:2:1 refactor: `Chef/Style/CommentFormat`
+- resolved cookstyle error: recipes/default.rb:5:1 refactor: `Chef/Style/CommentFormat`
+
 * Load template from xinetd cookbook unless explicitly overridden.
 * Fix foodcritic errors and add basic TravisCI configuration

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,11 +1,1 @@
-# -*- mode: ruby; coding: utf-8; -*-
-
-if defined?(ChefSpec)
-  def enable_xinetd_service(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:xinetd_service,
-                                            :enable,
-                                            resource_name)
-  end
-
-end
-
+# -*- mode: ruby; -*-

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,8 @@
 name             'xinetd'
 maintainer       'Steven Danna'
 maintainer_email 'steve@chef.io'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Installs/Configures xinetd'
-long_description 'Installs and configures the xinetd internet service daemon.  Also provides an LWRP for configuring xinetd services.'
 version          '1.0.2'
 
 supports 'ubuntu'
@@ -11,4 +10,4 @@ supports 'centos'
 
 source_url 'https://github.com/stevendanna/xinetd'
 issues_url 'https://github.com/stevendanna/xinetd/issues'
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 12.1'

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -1,4 +1,4 @@
-use_inline_resources
+
 
 action :enable do
   service 'xinetd' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: xinetd
+# Cookbook:: xinetd
 # Recipe:: default
 #
-# Copyright (C) 2013 Steven Danna
+# Copyright:: (C) 2013 Steven Danna
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.6 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with libraries/matchers.rb

 - 1:1 convention: `Style/Encoding` - Unnecessary utf-8 encoding comment. (https://rubystyle.guide#utf-8)
 - 3:1 refactor: `Chef/Modernize/DefinesChefSpecMatchers` - ChefSpec matchers are now auto generated by ChefSpec 7.1+ and do not need to be defined in a cookbook (https://docs.chef.io/workstation/cookstyle/chef_modernize_defineschefspecmatchers)
 - 11:1 convention: `Layout/TrailingEmptyLines` - 1 trailing blank lines detected. (https://rubystyle.guide#newline-eof)

### Issues found and resolved with metadata.rb

 - 4:18 refactor: `Chef/Sharing/InvalidLicenseString` - Cookbook metadata.rb does not use a SPDX compliant license string or "all rights reserved". See https://spdx.org/licenses/ for a complete list of license identifiers. (https://docs.chef.io/workstation/cookstyle/chef_sharing_invalidlicensestring)
 - 6:1 refactor: `Chef/RedundantCode/LongDescriptionMetadata` - The long_description metadata.rb method is not used and is unnecessary in cookbooks. (https://docs.chef.io/workstation/cookstyle/chef_redundantcode_longdescriptionmetadata)
 - 14:1 refactor: `Chef/Modernize/RespondToInMetadata` - It is no longer necessary to use respond_to? or defined? in metadata.rb in Chef Infra Client 12.15 and later (https://docs.chef.io/workstation/cookstyle/chef_modernize_respondtoinmetadata)

### Issues found and resolved with providers/service.rb

 - 1:1 warning: `Chef/Deprecations/UseInlineResourcesDefined` - use_inline_resources is now the default for resources in Chef Infra Client 13+ and does not need to be specified. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_useinlineresourcesdefined)

### Issues found and resolved with recipes/default.rb

 - 2:1 refactor: `Chef/Style/CommentFormat` - Properly format header comments (https://docs.chef.io/workstation/cookstyle/chef_style_commentformat)
 - 5:1 refactor: `Chef/Style/CommentFormat` - Properly format header comments (https://docs.chef.io/workstation/cookstyle/chef_style_commentformat)